### PR TITLE
feat: expose ad-network ids/names in attribution response model [LIN-1581]

### DIFF
--- a/LinkrunnerKit.podspec
+++ b/LinkrunnerKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'LinkrunnerKit'
-  s.version          = '3.11.0'
+  s.version          = '3.12.0'
   s.summary          = 'AI‑powered Mobile Measurement SDK.'
   s.description      = <<-DESC
     Native Swift SDK for Linkrunner.io—attribution, event & payment tracking.

--- a/LinkrunnerKit.podspec
+++ b/LinkrunnerKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'LinkrunnerKit'
-  s.version          = '3.10.0'
+  s.version          = '3.11.0'
   s.summary          = 'AI‑powered Mobile Measurement SDK.'
   s.description      = <<-DESC
     Native Swift SDK for Linkrunner.io—attribution, event & payment tracking.

--- a/LinkrunnerKit.podspec
+++ b/LinkrunnerKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'LinkrunnerKit'
-  s.version          = '4.0.0'
+  s.version          = '4.0.1'
   s.summary          = 'AI‑powered Mobile Measurement SDK.'
   s.description      = <<-DESC
     Native Swift SDK for Linkrunner.io—attribution, event & payment tracking.

--- a/Sources/Linkrunner/Linkrunner.swift
+++ b/Sources/Linkrunner/Linkrunner.swift
@@ -981,7 +981,7 @@ public class LinkrunnerSDK: @unchecked Sendable {
     }
     
     private func getPackageVersion() -> String {
-        return "4.0.0" // Swift package version
+        return "4.0.1" // Swift package version
     }
     
     private func getAppVersion() -> String {

--- a/Sources/Linkrunner/Linkrunner.swift
+++ b/Sources/Linkrunner/Linkrunner.swift
@@ -925,7 +925,7 @@ public class LinkrunnerSDK: @unchecked Sendable {
     }
     
     private func getPackageVersion() -> String {
-        return "3.10.0" // Swift package version
+        return "3.11.0" // Swift package version
     }
     
     private func getAppVersion() -> String {

--- a/Sources/Linkrunner/Linkrunner.swift
+++ b/Sources/Linkrunner/Linkrunner.swift
@@ -925,7 +925,7 @@ public class LinkrunnerSDK: @unchecked Sendable {
     }
     
     private func getPackageVersion() -> String {
-        return "3.11.0" // Swift package version
+        return "3.12.0" // Swift package version
     }
     
     private func getAppVersion() -> String {

--- a/Sources/Linkrunner/Models.swift
+++ b/Sources/Linkrunner/Models.swift
@@ -157,6 +157,11 @@ public struct CampaignData: Codable, Sendable {
     public let adNetwork: AdNetwork?
     public let groupName: String?
     public let assetGroupName: String?
+    public let adNetworkCampaignId: String?
+    public let adSetId: String?
+    public let adSetName: String?
+    public let adCreativeId: String?
+    public let adCreativeName: String?
     public let assetName: String?
     public let installedAt: Date?
     public let storeClickAt: Date?
@@ -176,6 +181,11 @@ public struct CampaignData: Codable, Sendable {
         case adNetwork = "ad_network"
         case groupName = "group_name"
         case assetGroupName = "asset_group_name"
+        case adNetworkCampaignId = "ad_network_campaign_id"
+        case adSetId = "ad_set_id"
+        case adSetName = "ad_set_name"
+        case adCreativeId = "ad_creative_id"
+        case adCreativeName = "ad_creative_name"
         case assetName = "asset_name"
         case installedAt = "installed_at"
         case storeClickAt = "store_click_at"
@@ -194,6 +204,11 @@ public struct CampaignData: Codable, Sendable {
         self.adNetwork = (dictionary["ad_network"] as? String).flatMap { AdNetwork(rawValue: $0) }
         self.groupName = dictionary["group_name"] as? String
         self.assetGroupName = dictionary["asset_group_name"] as? String
+        self.adNetworkCampaignId = dictionary["ad_network_campaign_id"] as? String
+        self.adSetId = dictionary["ad_set_id"] as? String
+        self.adSetName = dictionary["ad_set_name"] as? String
+        self.adCreativeId = dictionary["ad_creative_id"] as? String
+        self.adCreativeName = dictionary["ad_creative_name"] as? String
         self.assetName = dictionary["asset_name"] as? String
         
         // Parse date strings
@@ -234,7 +249,27 @@ public struct CampaignData: Codable, Sendable {
         if let assetGroupName = assetGroupName {
             dict["asset_group_name"] = assetGroupName
         }
-        
+
+        if let adNetworkCampaignId = adNetworkCampaignId {
+            dict["ad_network_campaign_id"] = adNetworkCampaignId
+        }
+
+        if let adSetId = adSetId {
+            dict["ad_set_id"] = adSetId
+        }
+
+        if let adSetName = adSetName {
+            dict["ad_set_name"] = adSetName
+        }
+
+        if let adCreativeId = adCreativeId {
+            dict["ad_creative_id"] = adCreativeId
+        }
+
+        if let adCreativeName = adCreativeName {
+            dict["ad_creative_name"] = adCreativeName
+        }
+
         if let assetName = assetName {
             dict["asset_name"] = assetName
         }


### PR DESCRIPTION
Adds the 5 new attribution fields the backend now returns in `getAttributionData → campaign_data` to this SDK's response model: `adNetworkCampaignId`, `adSetId`, `adSetName`, `adCreativeId`, `adCreativeName` (all optional / nullable), mapped from the backend snake_case keys (`ad_network_campaign_id`, `ad_set_id`, `ad_set_name`, `ad_creative_id`, `ad_creative_name`).

**Version:** 3.11.0 → **3.12.0**
**Linear:** LIN-1581

> ⚠️ **Publish this native SDK first.** The hybrid wrappers (RN / Flutter / Capacitor / Cordova) pin this release (`LinkrunnerKit 3.12.0`) — merge & publish this before those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)