### PR TITLE
feat: make payment_id mandatory for capturePayment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the LinkRunner iOS SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.12.0] - 2026-06-30
+
+### Changed
+
+- **Breaking:** `paymentId` is now required in `capturePayment`; the event is not dispatched when it is missing
+
 ## [3.10.0] - 2026-04-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the LinkRunner iOS SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.12.0] - 2026-06-30
+## [4.0.0] - 2026-06-30
 
 ### Changed
 

--- a/LinkrunnerKit.podspec
+++ b/LinkrunnerKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'LinkrunnerKit'
-  s.version          = '3.11.0'
+  s.version          = '3.12.0'
   s.summary          = 'AI‑powered Mobile Measurement SDK.'
   s.description      = <<-DESC
     Native Swift SDK for Linkrunner.io—attribution, event & payment tracking.

--- a/LinkrunnerKit.podspec
+++ b/LinkrunnerKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'LinkrunnerKit'
-  s.version          = '3.12.0'
+  s.version          = '4.0.0'
   s.summary          = 'AI‑powered Mobile Measurement SDK.'
   s.description      = <<-DESC
     Native Swift SDK for Linkrunner.io—attribution, event & payment tracking.

--- a/Sources/Linkrunner/Linkrunner.swift
+++ b/Sources/Linkrunner/Linkrunner.swift
@@ -981,7 +981,7 @@ public class LinkrunnerSDK: @unchecked Sendable {
     }
     
     private func getPackageVersion() -> String {
-        return "3.11.0" // Swift package version
+        return "3.12.0" // Swift package version
     }
     
     private func getAppVersion() -> String {

--- a/Sources/Linkrunner/Linkrunner.swift
+++ b/Sources/Linkrunner/Linkrunner.swift
@@ -498,7 +498,7 @@ public class LinkrunnerSDK: @unchecked Sendable {
             return
         }
 
-        guard !paymentId.isEmpty else {
+        guard !paymentId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             #if DEBUG
             print("Linkrunner: capturePayment failed - paymentId is required")
             #endif

--- a/Sources/Linkrunner/Linkrunner.swift
+++ b/Sources/Linkrunner/Linkrunner.swift
@@ -981,7 +981,7 @@ public class LinkrunnerSDK: @unchecked Sendable {
     }
     
     private func getPackageVersion() -> String {
-        return "3.12.0" // Swift package version
+        return "4.0.0" // Swift package version
     }
     
     private func getAppVersion() -> String {

--- a/Sources/Linkrunner/Linkrunner.swift
+++ b/Sources/Linkrunner/Linkrunner.swift
@@ -478,7 +478,7 @@ public class LinkrunnerSDK: @unchecked Sendable {
     /// - Parameters:
     ///   - amount: Payment amount
     ///   - userId: User identifier
-    ///   - paymentId: Optional payment identifier
+    ///   - paymentId: Payment identifier (required)
     ///   - type: Optional payment type
     ///   - status: Optional payment status
     ///   - eventData: Optional event data
@@ -486,7 +486,7 @@ public class LinkrunnerSDK: @unchecked Sendable {
     public func capturePayment(
         amount: Double,
         userId: String,
-        paymentId: String? = nil,
+        paymentId: String,
         type: PaymentType = .default,
         status: PaymentStatus = .completed,
         eventData: SendableDictionary? = nil
@@ -494,6 +494,13 @@ public class LinkrunnerSDK: @unchecked Sendable {
         guard let token = self.token else {
             #if DEBUG
             print("Linkrunner: capturePayment failed - SDK not initialized")
+            #endif
+            return
+        }
+
+        guard !paymentId.isEmpty else {
+            #if DEBUG
+            print("Linkrunner: capturePayment failed - paymentId is required")
             #endif
             return
         }
@@ -508,11 +515,9 @@ public class LinkrunnerSDK: @unchecked Sendable {
             "event_data": eventData as Any,
             "install_instance_id": await getLinkRunnerInstallInstanceId(),
             "time_since_app_install": getTimeSinceAppInstall(),
+            "payment_id": paymentId,
         ]
-        if let paymentId = paymentId {
-            requestData["payment_id"] = paymentId
-        }
-        
+
         requestData["type"] = type.rawValue
         requestData["status"] = status.rawValue
         
@@ -532,7 +537,7 @@ public class LinkrunnerSDK: @unchecked Sendable {
             #if DEBUG
             print("Linkrunner: Payment captured successfully ", [
                 "amount": amount,
-                "paymentId": paymentId ?? "N/A",
+                "paymentId": paymentId,
                 "userId": resolvedUserId,
                 "type": type.rawValue,
                 "status": status.rawValue


### PR DESCRIPTION
## Summary

Makes `payment_id` mandatory for the `capturePayment` payment event ([LIN-1649](https://linear.app/linkrunner/issue/LIN-1649/make-payment-id-mandatory-across-sdks)). Previously `paymentId` was optional, so a payment could be captured without it — weakening idempotent dedup and attribution, which key off `type` + `payment_id`. It is now required and validated before the event is dispatched.

`removePayment` is intentionally **unchanged** — it still accepts either `paymentId` or `userId` (removing by `userId` deletes all of a user's payments).

## Changes

- `capturePayment(...)`: `paymentId` param changed from `String? = nil` to a required `String`.
- Added a guard that returns early (logging in DEBUG) when `paymentId` is empty, so the event is not dispatched without `payment_id`.
- `payment_id` is now always included in the request body; updated the doc comment from "Optional" to "required".

## Testing

- The package is iOS-only (`.iOS(.v15)`); `swift build` targets the macOS host and fails on pre-existing iOS-only API availability errors (`NWPathMonitor`, `ATTrackingManager`, `SHA256`) unrelated to this change, and only Xcode Command Line Tools (no `xcodebuild`) are available in my environment, so an iOS-target build could not be run locally. The change is a straightforward signature + guard edit with no errors in the edited region.

🤖 Generated with [Claude Code](https://claude.com/claude-code)