### PR TITLE
docs: add LIN-1581 changelog entry (missed in #22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the LinkRunner iOS SDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.1] - 2026-07-09
+
+### Added
+
+- Exposed ad-network attribution fields on the attribution response: `adNetworkCampaignId`, `adSetId`, `adSetName`, `adCreativeId`, `adCreativeName` (all optional).
+
 ## [4.0.0] - 2026-06-30
 
 ### Changed


### PR DESCRIPTION
Adds the LIN-1581 CHANGELOG entry that was pushed **after** the original PR #22 had already been merged, so it never made it into `main`.

Changelog-only — no code changes. The version bump and native `4.0.1` refs are already in `main` from #22.

Ref: LIN-1581

🤖 Generated with [Claude Code](https://claude.com/claude-code)